### PR TITLE
Fix dependency sort order, Swift Package dropped randomly

### DIFF
--- a/Sources/Converter/ProjectConverter.swift
+++ b/Sources/Converter/ProjectConverter.swift
@@ -25,9 +25,17 @@ public struct ProjectConverter {
             nativeTarget.packageProductDependencies.forEach { dependency in
                 switch dependency.type {
                 case .remote:
-                    accumulators.0.append(dependency)
+                    if !accumulators.0.contains(where: {
+                        $0.name == dependency.name
+                    }) {
+                        accumulators.0.append(dependency)
+                    }
                 case .local:
-                    accumulators.1.append(dependency)
+                    if !accumulators.1.contains(where: {
+                        $0.name == dependency.name
+                    }) {
+                        accumulators.1.append(dependency)
+                    }
                 }
             }
 

--- a/Sources/Formatter/Mermaid/MermaidFormatter.swift
+++ b/Sources/Formatter/Mermaid/MermaidFormatter.swift
@@ -117,13 +117,19 @@ public struct MermaidFormatter {
 
         let formatNodeEdge = NodeEdgeFormatter()
 
-        project.nativeTargets.forEach { native in
-            result += native.targetDependencies.reduce("") { result, connectedNode in
+        project.nativeTargets
+            .sorted( by: { $0.name < $1.name } )
+            .forEach { native in
+            result += native.targetDependencies
+                .sorted(by: { $0.name < $1.name })
+                .reduce("") { result, connectedNode in
                 result + formatNodeEdge(node: native.name, connectedNode: connectedNode.name)
             }
 
             if swiftPackageOutput {
-                result += native.packageProductDependencies.reduce("") { result, connectedNode in
+                result += native.packageProductDependencies
+                    .sorted(by: { $0.name < $1.name })
+                    .reduce("") { result, connectedNode in
                     result + formatNodeEdge(node: native.name, connectedNode: connectedNode.name)
                 }
             }
@@ -143,6 +149,7 @@ public struct MermaidFormatter {
                     return vendorOutput
                 }
             }
+            .sorted(by: { $0.name < $1.name })
             .reduce("") { result, connectedNode in
                 result + formatNodeEdge(node: native.name, connectedNode: connectedNode.name)
             }

--- a/Sources/Generator/ProjectMaker.swift
+++ b/Sources/Generator/ProjectMaker.swift
@@ -40,8 +40,9 @@ struct ProjectMaker {
                             $0.packageProductDependencies.map {
                                 if let package = $0.package, let urlString = package.repositoryURL {
                                     return .init(
-                                        id: package.uuid,
+                                        id: $0.uuid,
                                         name: $0.productName,
+                                        packageName: package.name,
                                         type: .remote(
                                             urlString: urlString
                                         )
@@ -50,6 +51,7 @@ struct ProjectMaker {
                                     return .init(
                                         id: $0.uuid,
                                         name: $0.productName,
+                                        packageName: nil,
                                         type: .local
                                     )
                                 }

--- a/Sources/Value/Project.swift
+++ b/Sources/Value/Project.swift
@@ -90,15 +90,18 @@ public struct Project {
 
         public var id: String
         public let name: String
+        public let packageName: String?
         public let type: DependencyType
 
         public init(
             id: String,
             name: String,
+            packageName: String?,
             type: DependencyType
         ) {
             self.id = id
             self.name = name
+            self.packageName = packageName
             self.type = type
         }
     }

--- a/Tests/MermaidFormatterTests.swift
+++ b/Tests/MermaidFormatterTests.swift
@@ -18,7 +18,10 @@ final class MermaidFormatterTests: XCTestCase {
                 .init(
                     id: "ShareExtension",
                     name: "ShareExtension",
-                    targetDependencies: [.init(id: "B", name: "Core")],
+                    targetDependencies: [
+                        .init(id: "B", name: "Core"),
+                        .init(id: "C", name: "LibraryC")
+                    ],
                     packageProductDependencies: [],
                     otherDependencies: []
                 )
@@ -43,6 +46,7 @@ final class MermaidFormatterTests: XCTestCase {
             end
             App --> Core
             ShareExtension --> Core
+            ShareExtension --> LibraryC
             ```
 
             """

--- a/Tests/ProjectConverterTests.swift
+++ b/Tests/ProjectConverterTests.swift
@@ -7,17 +7,20 @@ final class ProjectConverterTests: XCTestCase {
 
     func testReduce() {
         let packageProductA = Project.SwiftPackage(
-            id: "A", name: "A", type: .remote(urlString: "")
+            id: "A", name: "A", packageName: "A", type: .remote(urlString: "")
         )
-        let packageProductB = Project.SwiftPackage(
-            id: "B", name: "B", type: .remote(urlString: "")
+        let packageProductB1 = Project.SwiftPackage(
+            id: "B1", name: "B1", packageName: "B", type: .remote(urlString: "")
+        )
+        let packageProductB2 = Project.SwiftPackage(
+            id: "B2", name: "B2", packageName: "B", type: .remote(urlString: "")
         )
 
         let internalPackageProduct1 = Project.SwiftPackage(
-            id: "P1", name: "InternalProduct1", type: .local
+            id: "P1", name: "InternalProduct1", packageName: nil, type: .local
         )
         let internalPackageProduct2 = Project.SwiftPackage(
-            id: "P2", name: "InternalProduct2", type: .local
+            id: "P2", name: "InternalProduct2", packageName: nil, type: .local
         )
 
         let appleSDKあ = Project.Framework(
@@ -64,7 +67,8 @@ final class ProjectConverterTests: XCTestCase {
                     ],
                     packageProductDependencies: [
                         packageProductA,
-                        packageProductB,
+                        packageProductB1,
+                        packageProductB2,
                         internalPackageProduct1,
                         internalPackageProduct2
                     ],
@@ -91,7 +95,7 @@ final class ProjectConverterTests: XCTestCase {
 
         XCTAssertEqual(
             subject.packageProducts,
-            [packageProductA, packageProductB]
+            [packageProductA, packageProductB1, packageProductB2]
         )
 
         XCTAssertEqual(


### PR DESCRIPTION
## Example Project Structure

* Targets:
    * `MyApp` Target
        * Dependencies:
            * SwiftPackage RxSwift/RxCocoa
            * SwiftPackage RxSwift/RxSwift
            * Local Target `MyComponent1`
            * Local Target `MyComponent2`
    * `MyComponent1` Target
        * Dependencies:
            * Local Target `MyComponent2`
    * `MyComponent2` Target

## Problem1: Swift Package is randomly dropped

### expected

I expect this output for the example project.

```markdown
MyApp["MyApp"]
MyComponent1["MyComponent1"]
MyComponent2["MyComponent2"]
RxSwift["RxSwift"]
RxCocoa["RxCocoa"]
```

### actual

Swift Package is randomly dropped.

The output may be this:

```markdown
...
MyApp["MyApp"]
MyComponent1["MyComponent1"]
MyComponent2["MyComponent2"]
RxCocoa["RxCocoa"]
...
```

or the output may be this:

```markdown
...
MyApp["MyApp"]
MyComponent1["MyComponent1"]
MyComponent2["MyComponent2"]
RxSwift["RxSwift"]
...
```

## Problem2: Dependency List has random order

### expected

I expect this output for the example project (targets and dependencies has alphabetical order)

```markdown
MyApp -> MyComponent1
MyApp -> MyComponent2
MyApp -> RxSwift
MyComponent1 -> MyComponent2
```

### actual

The dependencies order has random order.

The output may be this:

```markdown
...
MyApp -> RxSwift
MyApp -> MyComponent2
MyApp -> MyComponent1
MyComponent1 -> MyComponent2
```

or the output may be this:

```markdown
MyComponent1 -> MyComponent2
MyApp -> RxSwift
MyApp -> MyComponent1
MyApp -> MyComponent2
```